### PR TITLE
fix bug where the `resources` field in the Kyverno test file was not …

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -108,7 +108,21 @@ func testCommandExecute(
 			// filter results
 			var filteredResults []v1alpha1.TestResult
 			for _, res := range test.Test.Results {
-				if filter.Apply(res) {
+				var matchedResources []string
+				if len(res.Resources) > 0 {
+					for _, resource := range res.Resources {
+						testResult := v1alpha1.TestResult{
+							Resources: []string{resource},
+						}
+						if filter.Apply(testResult) {
+							matchedResources = append(matchedResources, resource)
+						}
+					}
+					if len(matchedResources) > 0 {
+						res.Resources = matchedResources
+						filteredResults = append(filteredResults, res)
+					}
+				} else if filter.Apply(res) {
 					filteredResults = append(filteredResults, res)
 				}
 			}

--- a/cmd/cli/kubectl-kyverno/test/filter/filter.go
+++ b/cmd/cli/kubectl-kyverno/test/filter/filter.go
@@ -47,10 +47,7 @@ type resource struct {
 func (f resource) Apply(result v1alpha1.TestResult) bool {
 	if len(result.Resources) > 0 {
 		resource := result.Resources[0]
-		if wildcard.Match(f.value, resource) {
-			return true
-		}
-		return false
+		return wildcard.Match(f.value, resource)
 	}
 	if result.Resource == "" {
 		return true

--- a/cmd/cli/kubectl-kyverno/test/filter/filter.go
+++ b/cmd/cli/kubectl-kyverno/test/filter/filter.go
@@ -45,6 +45,13 @@ type resource struct {
 }
 
 func (f resource) Apply(result v1alpha1.TestResult) bool {
+	if len(result.Resources) > 0 {
+		resource := result.Resources[0]
+		if wildcard.Match(f.value, resource) {
+			return true
+		}
+		return false
+	}
 	if result.Resource == "" {
 		return true
 	}


### PR DESCRIPTION
…considered

The `resource` field has been deprecated in favor of the `resources` field. Previously, when running a command like:

    kyverno test . --test-case-selector "resource=nginx-deploy-pass"

the flag only considered the `resource` field in the test file, ignoring the `resources` field if present.

This commit updates the filtering logic to apply the flag to the elements of the `resources` field if it is present.

This commit does the following:
- If both `resource` and `resources` fields are present, only `resources` is considered.
- If only the `resource` field is present, it is used.

## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
